### PR TITLE
Fix extra padding in Toga docs

### DIFF
--- a/src/beeware_theme/_static/beeware-theme.css
+++ b/src/beeware_theme/_static/beeware-theme.css
@@ -75,7 +75,8 @@ body[data-theme=auto] a.muted-link {
 .page h2 {
     font-family: 'Cutive', serif;
     font-size: 160%;
-    margin: 1.8rem 0 0.8rem 0;
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
     line-height: 2rem;
 }
 
@@ -86,7 +87,8 @@ body[data-theme=auto] a.muted-link {
 .page h3 {
     font-family: 'Cutive', serif;
     font-size: 135%;
-    margin: 1.8rem 0 0.8rem 0;
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
     line-height: 1.8rem;
 }
 
@@ -96,7 +98,8 @@ body[data-theme=auto] a.muted-link {
 
 .page h4 {
     font-family: 'Cutive', serif;
-    margin: 1.8rem 0 0.8rem 0;
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
     font-size: 120%;
     line-height: 1.6rem;
 }
@@ -109,7 +112,8 @@ body[data-theme=auto] a.muted-link {
 .page h5 {
     font-family: 'Cutive', serif;
     font-size: 110%;
-    margin: 1.8rem 0 0.8rem;
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
     line-height: 1.6rem;
 }
 
@@ -119,7 +123,8 @@ body[data-theme=auto] a.muted-link {
 
 .page h6 {
     font-family: 'Cutive', serif;
-    margin: 1.8rem 0 0.8rem 0;
+    margin-top: 1.8rem;
+    margin-bottom: 0.8rem;
     font-size: 100%;
     line-height: 1.6rem;
 }


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

There's a default margin that cancels the padding of 0.5rem that gots mysteriously inserted; don't explicitly set 0.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
