### PR TITLE
Make init args optional

### DIFF
--- a/src/beeware_theme/__init__.py
+++ b/src/beeware_theme/__init__.py
@@ -1,7 +1,20 @@
 from pathlib import Path
 
 
-def init(project_name, templates, context, static, css, theme_options):
+def init(
+    project_name,
+    templates=None,
+    context=None,
+    static=None,
+    css=None,
+    theme_options=None,
+):
+    templates = [] if templates is None else templates
+    context = {} if context is None else context
+    static = [] if static is None else static
+    css = [] if css is None else css
+    theme_options = {} if theme_options is None else theme_options
+
     context["github_project_name"] = project_name
 
     templates.append(str(Path(__file__).parent / "_templates"))


### PR DESCRIPTION
Makes `init` arguments optional.

https://github.com/beeware/beeware-theme/pull/7 highlighted a break in building docs, because of the `theme_options` introduced in https://github.com/beeware/beeware-theme/pull/7. With default values, calls to it should work even without `theme_options` supplied by the caller.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
